### PR TITLE
restores Go-controller parity in the TypeScript Worker

### DIFF
--- a/api-controller/src/handlers/dwh.ts
+++ b/api-controller/src/handlers/dwh.ts
@@ -13,30 +13,42 @@ import { ordersHandler, orderItemsHandler } from "./dwh/orders";
 import { partCostsHandler, roleManagementHandler } from "./dwh/roles_and_costs";
 import { authHandler } from "./dwh/auth";
 import { dashboardHandler } from "./dwh/dashboard";
+import { requireUser, toResponse } from "../utils/auth";
 
 export async function dwhHandler(fullPath: string, env: Env, request: Request): Promise<Response> {
     const path = fullPath.replace(/^\/dwh/, "");
 
+    // /auth/* (register, login, refresh, logout, me, verify) is the only un-gated area.
     if (path.startsWith("/auth")) {
         return await authHandler(path, request, env);
     }
 
-    if (path.startsWith("/dashboard/")) {
-        return await dashboardHandler(request, env);
+    try {
+        // Every other DWH endpoint requires a valid token — matches the Go controller, where
+        // fetchData/HandleInsert/HandleUpdate/HandleDelete all call ValidateToken first.
+        // Per-write admin-role checks happen inside the individual handlers.
+        await requireUser(request, env);
+
+        if (path.startsWith("/dashboard/")) {
+            return await dashboardHandler(request, env);
+        }
+
+        if (path.startsWith("/bikemodels")) return await bikeModelsHandler(request, env);
+        if (path.startsWith("/bikes")) return await bikeHandler(request, env);
+        if (path.startsWith("/components")) return await componentsHandler(request, env);
+        if (path.startsWith("/customers")) return await customersHandler(request, env);
+        if (path.startsWith("/orders")) return await ordersHandler(request, env);
+        if (path.startsWith("/orderitems")) return await orderItemsHandler(request, env);
+        if (path.startsWith("/partcosts")) return await partCostsHandler(request, env);
+        if (path.startsWith("/projects")) return await projectsHandler(request, env);
+        if (path.startsWith("/rolemanagements")) return await roleManagementHandler(request, env);
+        if (path.startsWith("/users")) return await usersHandler(request, env);
+        if (path.startsWith("/user")) return await userHandler(request, env);
+        if (path.startsWith("/warehouseparts")) return await warehousePartsHandler(request, env);
+
+        return new Response(`DWH Sub-path "${path}" Not Found`, { status: 404 });
+    } catch (e) {
+        // Converts HttpError thrown by requireUser/requireProjectRole/resolveProjectId etc.
+        return toResponse(e);
     }
-
-    if (path.startsWith("/bikemodels")) return await bikeModelsHandler(request, env);
-    if (path.startsWith("/bikes")) return await bikeHandler(request, env);
-    if (path.startsWith("/components")) return await componentsHandler(request, env);
-    if (path.startsWith("/customers")) return await customersHandler(request, env);
-    if (path.startsWith("/orders")) return await ordersHandler(request, env);
-    if (path.startsWith("/orderitems")) return await orderItemsHandler(request, env);
-    if (path.startsWith("/partcosts")) return await partCostsHandler(request, env);
-    if (path.startsWith("/projects")) return await projectsHandler(request, env);
-    if (path.startsWith("/rolemanagements")) return await roleManagementHandler(request, env);
-    if (path.startsWith("/users")) return await usersHandler(request, env);
-    if (path.startsWith("/user")) return await userHandler(request, env);
-    if (path.startsWith("/warehouseparts")) return await warehousePartsHandler(request, env);
-
-    return new Response(`DWH Sub-path "${path}" Not Found`, { status: 404 });
 }

--- a/api-controller/src/handlers/dwh/auth.ts
+++ b/api-controller/src/handlers/dwh/auth.ts
@@ -25,6 +25,39 @@ const getCookieOptions = (req: Request) => {
     return `HttpOnly; Path=/; Max-Age=900; SameSite=${isSecure ? 'None' : 'Lax'}${isSecure ? '; Secure' : ''}`;
 };
 
+// Sends the verification email via the Resend HTTP API (Workers have no SMTP, unlike the Go code's
+// smtp.gmail.com). Skipped when DISABLE_EMAILS=true or when no provider is configured (local/dev),
+// so registration still works without an email account — parity with Go's DISABLE_EMAILS gate.
+const sendVerificationEmail = async (env: Env, toEmail: string, token: string) => {
+    if (env.DISABLE_EMAILS === "true") return;
+    if (!env.RESEND_API_KEY || !env.EMAIL_FROM) {
+        console.warn("Verification email not sent: RESEND_API_KEY / EMAIL_FROM not configured");
+        return;
+    }
+    const base = (env.APP_BASE_URL || "").replace(/\/$/, "");
+    const link = `${base}/dwh/auth/verify?token=${token}`;
+    try {
+        const res = await fetch("https://api.resend.com/emails", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${env.RESEND_API_KEY}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                from: env.EMAIL_FROM,
+                to: toEmail,
+                subject: "Please confirm your e-mail address for NebulaDW",
+                html: `<p>Welcome to NebulaDW!</p><p>Please confirm your e-mail address by clicking <a href="${link}">this link</a>.</p>`,
+            }),
+        });
+        if (!res.ok) {
+            console.error("Verification email failed:", res.status, await res.text());
+        }
+    } catch (e) {
+        console.error("Verification email error:", e);
+    }
+};
+
 // POST /auth/register
 export const handleRegister = async (req: Request, env: Env) => {
     try {
@@ -48,7 +81,8 @@ export const handleRegister = async (req: Request, env: Env) => {
             .bind(user.username, user.email, hashedPassword, user.dob, verificationExpires, verificationToken)
             .run();
 
-        // TODO: Send verification email (requires external service like SendGrid/MailChannels in Worker)
+        // Send the verification email (no-op when emails are disabled / unconfigured).
+        await sendVerificationEmail(env, user.email, verificationToken);
 
         const token = await createJWT(user.email, env.JWT_SECRET);
 
@@ -185,12 +219,39 @@ export const handleMe = async (req: Request, env: Env) => {
     }
 }
 
+// GET /auth/verify?token=...  (port of Go's HandleEmailVerification)
+export const handleVerify = async (req: Request, env: Env) => {
+    const url = new URL(req.url);
+    const token = url.searchParams.get("token");
+    if (!token) return errorResponse("Verification token missing", 400);
+
+    const user = await env.DB.prepare(
+        "SELECT email, verification_expires FROM users WHERE verification_token = ?"
+    ).bind(token).first<{ email: string; verification_expires: string | null }>();
+
+    if (!user) return errorResponse("Invalid or expired verification token", 400);
+
+    if (user.verification_expires && new Date(user.verification_expires).getTime() < Date.now()) {
+        return errorResponse("Verification token has expired", 400);
+    }
+
+    await env.DB.prepare(
+        "UPDATE users SET is_verified = TRUE, verification_token = NULL, verification_expires = NULL WHERE verification_token = ?"
+    ).bind(token).run();
+
+    return new Response("Email successfully confirmed! You can now log in.", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+    });
+};
+
 export const authHandler = async (subPath: string, req: Request, env: Env) => {
     // subPath is expected to be "/auth/register" or "/auth/login" or "/auth/refresh" or "/auth/me"
     if (subPath.startsWith("/auth/register")) return handleRegister(req, env);
     if (subPath.startsWith("/auth/login")) return handleLogin(req, env);
     if (subPath.startsWith("/auth/refresh")) return handleRefresh(req, env);
     if (subPath.startsWith("/auth/logout")) return handleLogout(req, env);
+    if (subPath.startsWith("/auth/verify")) return handleVerify(req, env);
     if (subPath.startsWith("/auth/me")) return handleMe(req, env);
 
     return errorResponse(`Auth method "${subPath}" not found`, 404);

--- a/api-controller/src/handlers/dwh/bikes.ts
+++ b/api-controller/src/handlers/dwh/bikes.ts
@@ -1,5 +1,6 @@
 import { Env } from "../../types";
 import { queryWithPagination } from "./pagination";
+import { readJson, requireProjectRole, resolveProjectId } from "../../utils/auth";
 
 // Helper for error responses
 const errorResponse = (msg: string, status = 400) => new Response(msg, { status });
@@ -28,10 +29,11 @@ export const getBikes = async (req: Request, env: Env) => {
 
 // POST /bikes
 export const insertBike = async (req: Request, env: Env) => {
+    const bike: any = await readJson(req);
+    await requireProjectRole(req, env, bike.project_id, "admin");
     try {
-        const bike: any = await req.json();
         const query = `
-            INSERT INTO bikes (project_id, model_id, serial_number, production_date, quantity, warehouse_location) 
+            INSERT INTO bikes (project_id, model_id, serial_number, production_date, quantity, warehouse_location)
             VALUES (?, ?, ?, ?, ?, ?)
         `;
         await env.DB.prepare(query)
@@ -39,19 +41,20 @@ export const insertBike = async (req: Request, env: Env) => {
             .run();
         return new Response("Bike created", { status: 201 });
     } catch (e) {
-        return errorResponse("Error processing request: " + e);
+        console.error("insertBike failed:", e);
+        return errorResponse("Could not create bike", 500);
     }
 };
 
 // PUT /bikes
 export const updateBike = async (req: Request, env: Env) => {
+    const bike: any = await readJson(req);
+    if (!bike.id) return errorResponse("ID missing");
+    await requireProjectRole(req, env, bike.project_id, "admin");
     try {
-        const bike: any = await req.json();
-        if (!bike.id) return errorResponse("ID missing");
-
         const query = `
-            UPDATE bikes 
-            SET model_id = ?, serial_number = ?, production_date = ?, quantity = ?, warehouse_location = ?, project_id = ? 
+            UPDATE bikes
+            SET model_id = ?, serial_number = ?, production_date = ?, quantity = ?, warehouse_location = ?, project_id = ?
             WHERE id = ?
         `;
         await env.DB.prepare(query)
@@ -59,7 +62,8 @@ export const updateBike = async (req: Request, env: Env) => {
             .run();
         return new Response("Bike updated", { status: 200 });
     } catch (e) {
-        return errorResponse("Error processing request: " + e);
+        console.error("updateBike failed:", e);
+        return errorResponse("Could not update bike", 500);
     }
 };
 
@@ -70,6 +74,10 @@ export const deleteBike = async (req: Request, env: Env) => {
     const cascade = url.searchParams.get("cascade") === "true";
 
     if (!id) return errorResponse("Bad request – missing or invalid ID");
+
+    // Derive the project from the row, then require admin on it (mirrors Go's projectIdQuery).
+    const projectId = await resolveProjectId(env, "SELECT project_id FROM bikes WHERE id = ?", id);
+    await requireProjectRole(req, env, projectId, "admin");
 
     try {
         if (cascade) {

--- a/api-controller/src/handlers/dwh/crud.ts
+++ b/api-controller/src/handlers/dwh/crud.ts
@@ -1,9 +1,26 @@
 import { Env } from "../../types";
 import { queryWithPagination } from "./pagination";
-import { getValidUserEmail } from "../../utils/jwt";
+import {
+    getAllowedProjectIds,
+    readJson,
+    requireProjectRole,
+    requireUser,
+    resolveProjectId,
+} from "../../utils/auth";
+
+interface CrudOptions {
+    // Column on this table that holds the owning project_id. When set, writes require
+    // admin on that project (mirrors Go's HandleInsert/Update/Delete + ValidateProjectAccess).
+    projectColumn?: string;
+    // When true the table is read-only (GET only) — writes return 405. Matches the Go
+    // controller, where bike_models / components / users have no insert/update/delete handlers.
+    readOnly?: boolean;
+}
+
+const methodNotAllowed = () => new Response("Method not allowed", { status: 405 });
 
 // Generic CRUD helper
-const createCrudHandlers = (table: string, columns: string[]) => {
+const createCrudHandlers = (table: string, columns: string[], options: CrudOptions = {}) => {
     return {
         getAll: async (req: Request, env: Env) => {
             const baseQuery = `SELECT * FROM ${table}`;
@@ -11,8 +28,12 @@ const createCrudHandlers = (table: string, columns: string[]) => {
             return await queryWithPagination(req, env, baseQuery, countQuery);
         },
         insert: async (req: Request, env: Env) => {
+            if (options.readOnly) return methodNotAllowed();
+            const data: any = await readJson(req);
+            if (options.projectColumn) {
+                await requireProjectRole(req, env, data[options.projectColumn], "admin");
+            }
             try {
-                const data: any = await req.json();
                 const placeholders = columns.map(() => "?").join(", ");
                 const values = columns.map(col => data[col]);
                 await env.DB.prepare(`INSERT INTO ${table} (${columns.join(", ")}) VALUES (${placeholders})`)
@@ -20,13 +41,18 @@ const createCrudHandlers = (table: string, columns: string[]) => {
                     .run();
                 return new Response("Created", { status: 201 });
             } catch (e) {
-                return new Response("Error: " + e, { status: 400 });
+                console.error(`insert ${table} failed:`, e);
+                return new Response("Could not create record", { status: 500 });
             }
         },
         update: async (req: Request, env: Env) => {
+            if (options.readOnly) return methodNotAllowed();
+            const data: any = await readJson(req);
+            if (!data.id) return new Response("ID missing", { status: 400 });
+            if (options.projectColumn) {
+                await requireProjectRole(req, env, data[options.projectColumn], "admin");
+            }
             try {
-                const data: any = await req.json();
-                if (!data.id) return new Response("ID missing", { status: 400 });
                 const setClause = columns.map(col => `${col} = ?`).join(", ");
                 const values = columns.map(col => data[col]);
                 await env.DB.prepare(`UPDATE ${table} SET ${setClause} WHERE id = ?`)
@@ -34,14 +60,26 @@ const createCrudHandlers = (table: string, columns: string[]) => {
                     .run();
                 return new Response("Updated", { status: 200 });
             } catch (e) {
-                return new Response("Error: " + e, { status: 400 });
+                console.error(`update ${table} failed:`, e);
+                return new Response("Could not update record", { status: 500 });
             }
         },
         delete: async (req: Request, env: Env) => {
+            if (options.readOnly) return methodNotAllowed();
             const url = new URL(req.url);
             const id = url.searchParams.get("id");
             const cascade = url.searchParams.get("cascade") === "true";
             if (!id) return new Response("Bad request – missing or invalid ID", { status: 400 });
+
+            if (options.projectColumn) {
+                const projectId = await resolveProjectId(
+                    env,
+                    `SELECT ${options.projectColumn} AS project_id FROM ${table} WHERE id = ?`,
+                    id
+                );
+                await requireProjectRole(req, env, projectId, "admin");
+            }
+
             try {
                 if (cascade) {
                     // Define cascade dependencies per table
@@ -80,27 +118,28 @@ const createCrudHandlers = (table: string, columns: string[]) => {
                 if (msg.includes("FOREIGN KEY") || msg.includes("FOREIGN_KEY") || msg.includes("SQLITE_CONSTRAINT")) {
                     return new Response("Conflict – related data exists; use cascade=true to force delete", { status: 409 });
                 }
-                return new Response("Error: " + msg, { status: 500 });
+                console.error(`delete ${table} failed:`, e);
+                return new Response("Could not delete record", { status: 500 });
             }
         },
         handler: async (req: Request, env: Env) => {
-            const handlers = createCrudHandlers(table, columns);
+            const handlers = createCrudHandlers(table, columns, options);
             switch (req.method) {
                 case "GET": return handlers.getAll(req, env);
                 case "POST": return handlers.insert(req, env);
                 case "PUT": return handlers.update(req, env);
                 case "DELETE": return handlers.delete(req, env);
-                default: return new Response("Method not allowed", { status: 405 });
+                default: return methodNotAllowed();
             }
         }
     };
 };
 
-// Bike Models
+// Bike Models — read-only in the Go controller (GetBikeModels only)
 export const bikeModelsHandler = (req: Request, env: Env) =>
-    createCrudHandlers("bike_models", ["name", "saddle_id", "frame_id", "fork_id"]).handler(req, env);
+    createCrudHandlers("bike_models", ["name", "saddle_id", "frame_id", "fork_id"], { readOnly: true }).handler(req, env);
 
-// Components – queries saddles, frames, or forks based on ?filter=type:$eq.{type}
+// Components – queries saddles, frames, or forks based on ?filter=type:$eq.{type}. Read-only (matches Go).
 export const componentsHandler = async (req: Request, env: Env) => {
     const url = new URL(req.url);
     const filter = url.searchParams.get("filter") || "";
@@ -124,49 +163,78 @@ export const componentsHandler = async (req: Request, env: Env) => {
         return Response.json(results);
     }
 
-    return createCrudHandlers(tableName, ["name"]).handler(req, env);
+    return methodNotAllowed();
 }
 
-// Customers
+// Customers — writes require admin on the row's project_id
 export const customersHandler = (req: Request, env: Env) =>
-    createCrudHandlers("customers", ["email", "first_name", "name", "dob", "city", "project_id"]).handler(req, env);
+    createCrudHandlers(
+        "customers",
+        ["email", "first_name", "name", "dob", "city", "project_id"],
+        { projectColumn: "project_id" }
+    ).handler(req, env);
 
-// Projects — custom handler to auto-assign creator role on creation
+// Projects — GET is scoped to the caller's projects; POST auto-assigns creator; PUT/DELETE
+// require the creator role on the target project.
 export const projectsHandler = async (req: Request, env: Env) => {
+    if (req.method === "GET") {
+        // Mirrors Go's GetProjectsForUserByRole: only projects where the caller has >= requiredRole.
+        const email = await requireUser(req, env);
+        const url = new URL(req.url);
+        const requiredRole = url.searchParams.get("requiredRole") || "user";
+        const ids = await getAllowedProjectIds(env, email, requiredRole);
+        if (ids.length === 0) return Response.json([]);
+        const placeholders = ids.map(() => "?").join(", ");
+        const { results } = await env.DB.prepare(
+            `SELECT id, name FROM projects WHERE id IN (${placeholders})`
+        ).bind(...ids).all();
+        return Response.json(results);
+    }
+
     if (req.method === "POST") {
+        // Creating a project is allowed for any authenticated user; they become its creator.
+        const email = await requireUser(req, env);
+        const data: any = await readJson(req);
         try {
-            const data: any = await req.json();
-
-            // Extract user email from JWT
-            const userEmail = await getValidUserEmail(req, env);
-
-            // Insert project
             const result = await env.DB.prepare("INSERT INTO projects (name) VALUES (?)").bind(data.name).run();
             const projectId = result.meta?.last_row_id;
-
-            // Auto-assign creator role if we have the user email and project ID
-            if (userEmail && projectId) {
+            if (projectId) {
                 await env.DB.prepare(
                     "INSERT INTO role_management (useremail, project_id, role) VALUES (?, ?, 'creator')"
-                ).bind(userEmail, projectId).run();
+                ).bind(email, projectId).run();
             }
-
             return new Response("Created", { status: 201 });
         } catch (e) {
-            return new Response("Error: " + e, { status: 400 });
+            console.error("create project failed:", e);
+            return new Response("Could not create project", { status: 500 });
         }
     }
 
-    // Delegate all other methods to the generic CRUD handler
-    return createCrudHandlers("projects", ["name"]).handler(req, env);
+    if (req.method === "PUT") {
+        const data: any = await readJson(req);
+        if (!data.id) return new Response("ID missing", { status: 400 });
+        // The project IS the resource — require creator on it.
+        await requireProjectRole(req, env, data.id, "creator");
+        return createCrudHandlers("projects", ["name"]).update(req, env);
+    }
+
+    if (req.method === "DELETE") {
+        const url = new URL(req.url);
+        const id = url.searchParams.get("id");
+        if (!id) return new Response("Bad request – missing or invalid ID", { status: 400 });
+        await requireProjectRole(req, env, id, "creator");
+        return createCrudHandlers("projects", ["name"]).delete(req, env);
+    }
+
+    return methodNotAllowed();
 };
 
-// Users (Simplified - use Auth for real logic)
+// Users — read-only here (registration/auth is handled by /auth). Matches Go's GetUsers/GetUser.
 export const usersHandler = (req: Request, env: Env) =>
-    createCrudHandlers("users", ["username", "email", "dob", "is_verified"]).handler(req, env);
+    createCrudHandlers("users", ["username", "email", "dob", "is_verified"], { readOnly: true }).handler(req, env);
 
 export const userHandler = async (req: Request, env: Env) => {
-    if (req.method !== "GET") return new Response("Method Not Allowed", { status: 405 });
+    if (req.method !== "GET") return methodNotAllowed();
 
     const url = new URL(req.url);
     const filter = url.searchParams.get("filter");
@@ -181,7 +249,10 @@ export const userHandler = async (req: Request, env: Env) => {
     return new Response("Filter missing or invalid", { status: 400 });
 };
 
-// Warehouse Parts
+// Warehouse Parts — writes require admin on the row's project_id
 export const warehousePartsHandler = (req: Request, env: Env) =>
-    createCrudHandlers("warehouse_parts", ["part_type", "part_id", "quantity", "storage_location", "project_id"]).handler(req, env);
-
+    createCrudHandlers(
+        "warehouse_parts",
+        ["part_type", "part_id", "quantity", "storage_location", "project_id"],
+        { projectColumn: "project_id" }
+    ).handler(req, env);

--- a/api-controller/src/handlers/dwh/dashboard.ts
+++ b/api-controller/src/handlers/dwh/dashboard.ts
@@ -1,5 +1,6 @@
 import { Env } from "../../types";
 import { GraphMeta, GraphData, CityData, BikeSales } from "../../models";
+import { getAllowedProjectIds, HttpError, requireUser } from "../../utils/auth";
 
 // Helper for error responses
 const errorResponse = (msg: string, status = 400) => new Response(msg, { status });
@@ -23,6 +24,25 @@ const parseProjectIds = (url: URL): number[] => {
     const eqMatch = filter.match(/project_id:\$eq\.(\d+)/);
     if (eqMatch) return [Number(eqMatch[1])];
     return [];
+};
+
+/**
+ * Resolve which project IDs this request may aggregate over (port of Go's filterProjectIDs):
+ * the requested IDs intersected with the caller's accessible projects. If the client requests
+ * none, fall back to all of the caller's projects. Throws 403 if they request only projects they
+ * cannot access. An empty array means "this user has no projects" → handlers return empty data.
+ */
+const scopedProjectIds = async (req: Request, env: Env): Promise<number[]> => {
+    const email = await requireUser(req, env);
+    const allowed = await getAllowedProjectIds(env, email, "user");
+    const requested = parseProjectIds(new URL(req.url));
+    if (requested.length === 0) return allowed;
+    const allowedSet = new Set(allowed);
+    const filtered = requested.filter(id => allowedSet.has(id));
+    if (filtered.length === 0) {
+        throw new HttpError(403, "You don't have access to the requested project(s)");
+    }
+    return filtered;
 };
 
 // Returns { sql: " AND o.project_id IN (?,?)", bindings: [1,2] } or empty
@@ -49,7 +69,10 @@ export const getGraphMeta = async (req: Request, env: Env) => {
     if (!range) return errorResponse("Range missing");
 
     const mods = getModifiers(range);
-    const projectIds = parseProjectIds(url);
+    const projectIds = await scopedProjectIds(req, env);
+    if (projectIds.length === 0) {
+        return Response.json([{ current_revenue: 0, previous_revenue: 0, current_sales: 0, previous_sales: 0 }]);
+    }
     const proj = buildProjectFilter(projectIds, "AND");
 
     let query: string;
@@ -57,7 +80,7 @@ export const getGraphMeta = async (req: Request, env: Env) => {
 
     if (mods.current) {
         query = `
-            SELECT 
+            SELECT
                 COALESCE((SELECT SUM(oi.price * oi.number) FROM order_items oi JOIN orders o ON oi.order_id = o.id WHERE date(o.order_date) >= date('now', ?)${proj.sql} AND date(o.order_date) < date('now', '+1 day')), 0) as current_revenue,
                 COALESCE((SELECT SUM(oi.price * oi.number) FROM order_items oi JOIN orders o ON oi.order_id = o.id WHERE date(o.order_date) >= date('now', ?) AND date(o.order_date) < date('now', ?)${proj.sql}), 0) as previous_revenue,
                 COALESCE((SELECT SUM(oi.number) FROM order_items oi JOIN orders o ON oi.order_id = o.id WHERE date(o.order_date) >= date('now', ?)${proj.sql} AND date(o.order_date) < date('now', '+1 day')), 0) as current_sales,
@@ -91,7 +114,8 @@ export const getGraphData = async (req: Request, env: Env) => {
     if (!range) return errorResponse("Range missing");
 
     const mods = getModifiers(range);
-    const projectIds = parseProjectIds(url);
+    const projectIds = await scopedProjectIds(req, env);
+    if (projectIds.length === 0) return Response.json([]);
     const proj = buildProjectFilter(projectIds, "AND");
 
     let query = `
@@ -125,7 +149,8 @@ export const getCityData = async (req: Request, env: Env) => {
     if (!range) return errorResponse("Range missing");
 
     const mods = getModifiers(range);
-    const projectIds = parseProjectIds(url);
+    const projectIds = await scopedProjectIds(req, env);
+    if (projectIds.length === 0) return Response.json([]);
     const proj = buildProjectFilter(projectIds, "AND");
 
     let query: string;
@@ -170,7 +195,8 @@ export const getBikeSales = async (req: Request, env: Env) => {
     if (!range) return errorResponse("Range missing");
 
     const mods = getModifiers(range);
-    const projectIds = parseProjectIds(url);
+    const projectIds = await scopedProjectIds(req, env);
+    if (projectIds.length === 0) return Response.json([]);
     const proj = buildProjectFilter(projectIds, "AND");
 
     let query = `

--- a/api-controller/src/handlers/dwh/orders.ts
+++ b/api-controller/src/handlers/dwh/orders.ts
@@ -1,5 +1,6 @@
 import { Env } from "../../types";
 import { queryWithPagination } from "./pagination";
+import { getAllowedProjectIds, readJson, requireProjectRole, requireUser, resolveProjectId } from "../../utils/auth";
 
 // Helper for error responses
 const errorResponse = (msg: string, status = 400) => new Response(msg, { status });
@@ -10,10 +11,15 @@ export const getOrders = async (req: Request, env: Env) => {
     const filter = url.searchParams.get("filter");
 
     if (filter && filter.includes("email:$eq.")) {
-        // Ported from select/orderbycustomerselect.sql
+        // Ported from select/orderbycustomerselect.sql — scoped to the caller's projects
+        // (the Go query filtered by `o.project_id = ANY($2)`).
+        const userEmail = await requireUser(req, env);
+        const allowed = await getAllowedProjectIds(env, userEmail, "user");
+        if (allowed.length === 0) return Response.json({ items: [], totalCount: 0 });
+        const placeholders = allowed.map(() => "?").join(", ");
         const baseQuery = `
-            SELECT 
-                oi.id, oi.order_id, oi.bike_id, oi.number, oi.price, 
+            SELECT
+                oi.id, oi.order_id, oi.bike_id, oi.number, oi.price,
                 bm.name as model_name, o.order_date,
                 o.project_id, c.email as email
             FROM orders o
@@ -21,6 +27,7 @@ export const getOrders = async (req: Request, env: Env) => {
             JOIN order_items oi ON o.id = oi.order_id
             JOIN bikes b ON oi.bike_id = b.id
             JOIN bike_models bm ON b.model_id = bm.id
+            WHERE o.project_id IN (${placeholders})
         `;
         const countQuery = `
             SELECT COUNT(*)
@@ -29,8 +36,9 @@ export const getOrders = async (req: Request, env: Env) => {
             JOIN order_items oi ON o.id = oi.order_id
             JOIN bikes b ON oi.bike_id = b.id
             JOIN bike_models bm ON b.model_id = bm.id
+            WHERE o.project_id IN (${placeholders})
         `;
-        return await queryWithPagination(req, env, baseQuery, countQuery);
+        return await queryWithPagination(req, env, baseQuery, countQuery, allowed);
     }
 
     // Default GET
@@ -50,28 +58,32 @@ export const getOrders = async (req: Request, env: Env) => {
 
 // POST /orders
 export const insertOrder = async (req: Request, env: Env) => {
+    const order: any = await readJson(req);
+    await requireProjectRole(req, env, order.project_id, "admin");
     try {
-        const order: any = await req.json();
         await env.DB.prepare(`INSERT INTO orders (customer_id, order_date, project_id) VALUES (?, ?, ?)`)
             .bind(order.customer_id, order.order_date, order.project_id)
             .run();
         return new Response("Order created", { status: 201 });
     } catch (e) {
-        return errorResponse("Error: " + e);
+        console.error("insertOrder failed:", e);
+        return errorResponse("Could not create order", 500);
     }
 };
 
 // PUT /orders
 export const updateOrder = async (req: Request, env: Env) => {
+    const order: any = await readJson(req);
+    if (!order.id) return errorResponse("ID missing");
+    await requireProjectRole(req, env, order.project_id, "admin");
     try {
-        const order: any = await req.json();
-        if (!order.id) return errorResponse("ID missing");
         await env.DB.prepare(`UPDATE orders SET order_date = ?, customer_id = ?, project_id = ? WHERE id = ?`)
             .bind(order.order_date, order.customer_id, order.project_id, order.id)
             .run();
         return new Response("Order updated", { status: 200 });
     } catch (e) {
-        return errorResponse("Error: " + e);
+        console.error("updateOrder failed:", e);
+        return errorResponse("Could not update order", 500);
     }
 };
 
@@ -82,6 +94,9 @@ export const deleteOrder = async (req: Request, env: Env) => {
     const cascade = url.searchParams.get("cascade") === "true";
 
     if (!id) return errorResponse("ID missing");
+
+    const projectId = await resolveProjectId(env, "SELECT project_id FROM orders WHERE id = ?", id);
+    await requireProjectRole(req, env, projectId, "admin");
 
     try {
         if (cascade) {
@@ -136,27 +151,34 @@ export const getOrderItems = async (req: Request, env: Env) => {
 };
 
 export const insertOrderItem = async (req: Request, env: Env) => {
+    const item: any = await readJson(req);
+    // The project lives on the parent order (mirrors Go's orderitems.go projectIdQuery).
+    const projectId = await resolveProjectId(env, "SELECT project_id FROM orders WHERE id = ?", item.order_id);
+    await requireProjectRole(req, env, projectId, "admin");
     try {
-        const item: any = await req.json();
         await env.DB.prepare(`INSERT INTO order_items (order_id, bike_id, number, price) VALUES (?, ?, ?, ?)`)
             .bind(item.order_id, item.bike_id, item.number, item.price)
             .run();
         return new Response("Order item created", { status: 201 });
     } catch (e) {
-        return errorResponse("Error: " + e);
+        console.error("insertOrderItem failed:", e);
+        return errorResponse("Could not create order item", 500);
     }
 };
 
 export const updateOrderItem = async (req: Request, env: Env) => {
+    const item: any = await readJson(req);
+    if (!item.id) return errorResponse("ID missing");
+    const projectId = await resolveProjectId(env, "SELECT project_id FROM orders WHERE id = ?", item.order_id);
+    await requireProjectRole(req, env, projectId, "admin");
     try {
-        const item: any = await req.json();
-        if (!item.id) return errorResponse("ID missing");
         await env.DB.prepare(`UPDATE order_items SET order_id = ?, bike_id = ?, number = ?, price = ? WHERE id = ?`)
             .bind(item.order_id, item.bike_id, item.number, item.price, item.id)
             .run();
         return new Response("Order item updated", { status: 200 });
     } catch (e) {
-        return errorResponse("Error: " + e);
+        console.error("updateOrderItem failed:", e);
+        return errorResponse("Could not update order item", 500);
     }
 };
 
@@ -164,6 +186,13 @@ export const deleteOrderItem = async (req: Request, env: Env) => {
     const url = new URL(req.url);
     const id = url.searchParams.get("id");
     if (!id) return errorResponse("ID missing");
+
+    const projectId = await resolveProjectId(
+        env,
+        "SELECT o.project_id FROM order_items oi JOIN orders o ON o.id = oi.order_id WHERE oi.id = ?",
+        id
+    );
+    await requireProjectRole(req, env, projectId, "admin");
 
     try {
         await env.DB.prepare("DELETE FROM order_items WHERE id = ?").bind(id).run();

--- a/api-controller/src/handlers/dwh/pagination.ts
+++ b/api-controller/src/handlers/dwh/pagination.ts
@@ -55,6 +55,23 @@ function appendFilters(query: string, conditions: string[]): string {
     return `SELECT * FROM (${query}) AS _filtered WHERE ${whereClause}`;
 }
 
+// Build an ORDER BY clause from the frontend's orderBy param (port of Go's applyPaginationAndSorting).
+// Format: "col=dir" comma-separated, e.g. "customer_name=asc,project_id=desc".
+// Columns/directions are whitelisted because the clause is string-built (no bind for identifiers).
+function buildOrderClause(orderByParam: string | null): string {
+    if (!orderByParam) return "";
+    const parts: string[] = [];
+    for (const segment of orderByParam.split(",")) {
+        const [rawCol, rawDir] = segment.split("=");
+        const col = (rawCol || "").trim();
+        const dir = (rawDir || "asc").trim().toLowerCase();
+        if (!/^[A-Za-z0-9_]+$/.test(col)) continue;
+        const safeDir = dir === "desc" ? "DESC" : "ASC";
+        parts.push(`${col} ${safeDir}`);
+    }
+    return parts.length ? ` ORDER BY ${parts.join(", ")}` : "";
+}
+
 export const queryWithPagination = async <T = any>(
     req: Request,
     env: Env,
@@ -74,11 +91,12 @@ export const queryWithPagination = async <T = any>(
             ? `SELECT COUNT(*) AS count FROM (${filteredBaseQuery})`
             : countQuery;
 
-        // Merge filter bindings before existing bindings
-        // For filteredCountQuery when derived from filteredBaseQuery, we need filterBindings + bindings
-        const allBindings = [...filterBindings, ...bindings];
-        // Count query needs double filterBindings when derived from filteredBaseQuery (subquery has its own set)
-        const countBindings = conditions.length > 0 ? [...filterBindings, ...bindings] : [...bindings];
+        // Binding order must match the SQL: the base query's own placeholders come first (they sit
+        // inside the wrapped subquery), then the filter placeholders in the outer WHERE.
+        const allBindings = [...bindings, ...filterBindings];
+        // When derived from filteredBaseQuery the count query embeds the same base+filter placeholders;
+        // when there's no filter we use the caller's countQuery, which only needs the base bindings.
+        const countBindings = conditions.length > 0 ? [...bindings, ...filterBindings] : [...bindings];
 
         // Handle countBy parameter for filter dropdowns
         const countBy = url.searchParams.get("countBy");
@@ -101,7 +119,8 @@ export const queryWithPagination = async <T = any>(
 
         const offset = (page - 1) * pageSize;
 
-        const paginatedQuery = `${filteredBaseQuery} LIMIT ? OFFSET ?`;
+        const orderClause = buildOrderClause(url.searchParams.get("orderBy"));
+        const paginatedQuery = `${filteredBaseQuery}${orderClause} LIMIT ? OFFSET ?`;
 
         const [countResult, itemsResult] = await env.DB.batch([
             env.DB.prepare(filteredCountQuery).bind(...countBindings),

--- a/api-controller/src/handlers/dwh/roles_and_costs.ts
+++ b/api-controller/src/handlers/dwh/roles_and_costs.ts
@@ -1,12 +1,18 @@
 import { Env } from "../../types";
 import { queryWithPagination } from "./pagination";
-import { getValidUserEmail } from "../../utils/jwt";
+import {
+    canModifyRole,
+    getAllowedProjectIds,
+    hasProjectRole,
+    readJson,
+    requireUser,
+} from "../../utils/auth";
 
 // Helper for error responses
 const errorResponse = (msg: string, status = 400) => new Response(msg, { status });
 
 // GET /rolemanagements
-// GET /rolemanagements?project_id=...&useremail=...
+// GET /rolemanagements/{id}
 // DELETE /rolemanagements?email=...&project_id=...
 // PUT /rolemanagements
 // POST /rolemanagements
@@ -15,10 +21,15 @@ export const getRoleManagement = async (req: Request, env: Env) => {
     const url = new URL(req.url);
     const path = url.pathname;
 
-    // Handle /rolemanagements/{id} — returns ALL roles for a specific project_id (used by Manage dialog)
+    // Handle /rolemanagements/{id} — returns ALL roles for a specific project_id (used by Manage dialog).
+    // Only a member of that project may view its roster.
     const idMatch = path.match(/\/rolemanagements\/(\d+)$/);
     if (idMatch) {
         const projectId = idMatch[1];
+        const email = await requireUser(req, env);
+        if (!(await hasProjectRole(env, email, projectId, "user"))) {
+            return errorResponse("You don't have access to this project", 403);
+        }
         const { results } = await env.DB.prepare(`
             SELECT useremail AS user_email, project_id, role, p.name as project_name
             FROM role_management
@@ -29,10 +40,7 @@ export const getRoleManagement = async (req: Request, env: Env) => {
     }
 
     // Default listing: only show roles for the currently authenticated user
-    const userEmail = await getValidUserEmail(req, env);
-    if (!userEmail) {
-        return errorResponse("Unauthorized – missing or invalid token", 401);
-    }
+    const userEmail = await requireUser(req, env);
 
     const baseQuery = `
         SELECT useremail AS user_email, project_id, role, p.name as project_name
@@ -56,14 +64,31 @@ export const roleManagementHandler = async (req: Request, env: Env) => {
     }
 
     if (req.method === "POST") {
+        const data: any = await readJson(req);
+        if (!data.user_email || !data.project_id || !data.role) {
+            return errorResponse("Missing required fields: user_email, project_id, role");
+        }
+        if (data.role === "creator") {
+            return errorResponse("Cannot manually assign the creator role.", 403);
+        }
+
+        const actor = await requireUser(req, env);
+        // Permission check (port of CanModifyRole; oldRole is "" because the assignment is new).
+        const denied = await canModifyRole(env, actor, data.project_id, data.user_email, "", data.role);
+        if (denied) return errorResponse(denied, 403);
+
+        // Target user must exist.
+        const userExists = await env.DB.prepare("SELECT 1 FROM users WHERE email = ?")
+            .bind(data.user_email).first();
+        if (!userExists) return errorResponse("User does not exist.", 400);
+
+        // Must not already be assigned to the project.
+        const already = await env.DB.prepare(
+            "SELECT 1 FROM role_management WHERE useremail = ? AND project_id = ?"
+        ).bind(data.user_email, data.project_id).first();
+        if (already) return errorResponse("User is already assigned to this project.", 409);
+
         try {
-            const data: any = await req.json();
-            if (!data.user_email || !data.project_id || !data.role) {
-                return errorResponse("Missing required fields: user_email, project_id, role");
-            }
-            if (data.role === "creator") {
-                return errorResponse("Cannot manually assign the creator role.", 403);
-            }
             await env.DB.prepare(
                 "INSERT INTO role_management (useremail, project_id, role) VALUES (?, ?, ?)"
             ).bind(data.user_email, data.project_id, data.role).run();
@@ -71,37 +96,46 @@ export const roleManagementHandler = async (req: Request, env: Env) => {
         } catch (e: any) {
             const msg = String(e);
             if (msg.includes("UNIQUE") || msg.includes("SQLITE_CONSTRAINT")) {
-                return new Response("Conflict – this user already has a role in this project", { status: 409 });
+                return errorResponse("Conflict – this user already has a role in this project", 409);
             }
-            return new Response("Error: " + msg, { status: 500 });
+            console.error("insert role failed:", e);
+            return errorResponse("Could not assign role", 500);
         }
     }
 
     if (req.method === "PUT") {
+        const data: any = await readJson(req);
+        if (!data.user_email || !data.project_id || !data.role) {
+            return errorResponse("Missing required fields: user_email, project_id, role");
+        }
+        if (data.role === "creator") {
+            return errorResponse("Cannot reassign a user to the creator role.", 403);
+        }
+
+        const actor = await requireUser(req, env);
+
+        const existing: any = await env.DB.prepare(
+            "SELECT role FROM role_management WHERE useremail = ? AND project_id = ?"
+        ).bind(data.user_email, data.project_id).first();
+        if (!existing) return errorResponse("Entry not found.", 404);
+        if (existing.role === "creator") {
+            return errorResponse("Cannot change the role of the project creator.", 403);
+        }
+
+        const denied = await canModifyRole(env, actor, data.project_id, data.user_email, existing.role, data.role);
+        if (denied) return errorResponse(denied, 403);
+
+        // No-op update.
+        if (existing.role === data.role) return new Response(null, { status: 204 });
+
         try {
-            const data: any = await req.json();
-            if (!data.user_email || !data.project_id || !data.role) {
-                return errorResponse("Missing required fields: user_email, project_id, role");
-            }
-            if (data.role === "creator") {
-                return errorResponse("Cannot reassign a user to the creator role.", 403);
-            }
-
-            // Check current role: cannot demote the creator
-            const existingRoleResult: any = await env.DB.prepare(
-                "SELECT role FROM role_management WHERE useremail = ? AND project_id = ?"
-            ).bind(data.user_email, data.project_id).first();
-
-            if (existingRoleResult?.role === "creator") {
-                return errorResponse("Cannot change the role of the project creator.", 403);
-            }
-
             await env.DB.prepare(
                 "UPDATE role_management SET role = ? WHERE useremail = ? AND project_id = ?"
             ).bind(data.role, data.user_email, data.project_id).run();
             return new Response("Updated", { status: 200 });
         } catch (e) {
-            return new Response("Error: " + e, { status: 500 });
+            console.error("update role failed:", e);
+            return errorResponse("Could not update role", 500);
         }
     }
 
@@ -112,22 +146,28 @@ export const roleManagementHandler = async (req: Request, env: Env) => {
         if (!email || !projectId) {
             return errorResponse("Missing required query params: email, project_id");
         }
+
+        const actor = await requireUser(req, env);
+
+        const existing: any = await env.DB.prepare(
+            "SELECT role FROM role_management WHERE useremail = ? AND project_id = ?"
+        ).bind(email, projectId).first();
+        if (!existing) return errorResponse("Entry not found.", 404);
+        if (existing.role === "creator") {
+            return errorResponse("Cannot remove the project creator.", 403);
+        }
+
+        const denied = await canModifyRole(env, actor, projectId, email, existing.role, "");
+        if (denied) return errorResponse(denied, 403);
+
         try {
-            // Cannot delete the creator
-            const existingRoleResult: any = await env.DB.prepare(
-                "SELECT role FROM role_management WHERE useremail = ? AND project_id = ?"
-            ).bind(email, projectId).first();
-
-            if (existingRoleResult?.role === "creator") {
-                return errorResponse("Cannot remove the project creator.", 403);
-            }
-
             await env.DB.prepare(
                 "DELETE FROM role_management WHERE useremail = ? AND project_id = ?"
             ).bind(email, projectId).run();
             return new Response("Deleted", { status: 200 });
         } catch (e) {
-            return new Response("Error: " + e, { status: 500 });
+            console.error("delete role failed:", e);
+            return errorResponse("Could not remove role", 500);
         }
     }
 
@@ -135,9 +175,15 @@ export const roleManagementHandler = async (req: Request, env: Env) => {
 };
 
 // --- Part Costs ---
-
+// Scoped to the caller's projects (port of Go's HandleGetWithProjectIDs).
 export const partCostsHandler = async (req: Request, env: Env) => {
-    const baseQuery = "SELECT * FROM part_costs";
-    const countQuery = "SELECT COUNT(*) FROM part_costs";
-    return await queryWithPagination(req, env, baseQuery, countQuery);
+    const email = await requireUser(req, env);
+    const allowed = await getAllowedProjectIds(env, email, "user");
+    if (allowed.length === 0) {
+        return Response.json({ items: [], totalCount: 0 });
+    }
+    const placeholders = allowed.map(() => "?").join(", ");
+    const baseQuery = `SELECT * FROM part_costs WHERE project_id IN (${placeholders})`;
+    const countQuery = `SELECT COUNT(*) FROM part_costs WHERE project_id IN (${placeholders})`;
+    return await queryWithPagination(req, env, baseQuery, countQuery, allowed);
 };

--- a/api-controller/src/types.ts
+++ b/api-controller/src/types.ts
@@ -4,4 +4,13 @@ export interface Env {
     CHAT_DB: D1Database;
     AI: Ai;
     JWT_SECRET: string;
+
+    // Email verification (optional — see handlers/dwh/auth.ts).
+    // Base URL the verification link points back at, e.g. https://danielfreiremendes.com/api
+    APP_BASE_URL?: string;
+    // When "true", registration skips sending the email (parity with Go's DISABLE_EMAILS).
+    DISABLE_EMAILS?: string;
+    // Resend HTTP API key + sender address used to deliver the verification email.
+    RESEND_API_KEY?: string;
+    EMAIL_FROM?: string;
 }

--- a/api-controller/src/utils/auth.ts
+++ b/api-controller/src/utils/auth.ts
@@ -1,0 +1,165 @@
+import { Env } from "../types";
+import { getValidUserEmail } from "./jwt";
+
+// Role hierarchy: creator > admin > user (port of controller/utils/project_id.go)
+const ROLE_PRIORITY: Record<string, number> = { user: 1, admin: 2, creator: 3 };
+
+/**
+ * Lightweight error carrying an HTTP status. Handlers throw it (e.g. from
+ * requireUser / requireProjectRole) and the top-level dwhHandler converts it to a
+ * Response via toResponse(). This mirrors the way the Go handlers short-circuit with
+ * http.Error(...).
+ */
+export class HttpError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+        super(message);
+        this.status = status;
+        this.name = "HttpError";
+    }
+}
+
+/** Convert a thrown value into a Response. HttpError keeps its status; anything else is a 500. */
+export function toResponse(e: unknown): Response {
+    if (e instanceof HttpError) {
+        return new Response(e.message, { status: e.status });
+    }
+    console.error("Unexpected error:", e);
+    return new Response("Internal Server Error", { status: 500 });
+}
+
+/** Parse a JSON body, throwing a 400 HttpError on malformed input (instead of leaking a 500). */
+export async function readJson<T = any>(req: Request): Promise<T> {
+    try {
+        return (await req.json()) as T;
+    } catch {
+        throw new HttpError(400, "Invalid JSON body");
+    }
+}
+
+/** = Go ValidateToken: returns the caller's email or throws 401. */
+export async function requireUser(req: Request, env: Env): Promise<string> {
+    const email = await getValidUserEmail(req, env);
+    if (!email) throw new HttpError(401, "Unauthorized – missing or invalid token");
+    return email;
+}
+
+function hasSufficientRole(current: string, required: string): boolean {
+    return (ROLE_PRIORITY[current] ?? 0) >= (ROLE_PRIORITY[required] ?? 0);
+}
+
+/** = Go GetUserRole: the caller's role on a project, or null if they have none. */
+export async function getUserRole(
+    env: Env,
+    email: string,
+    projectId: number | string
+): Promise<string | null> {
+    const row = await env.DB.prepare(
+        "SELECT role FROM role_management WHERE useremail = ? AND project_id = ?"
+    )
+        .bind(email, projectId)
+        .first<{ role: string }>();
+    return row?.role ?? null;
+}
+
+/** = Go GetProjectIDForUser: does the user hold at least requiredRole on this project? */
+export async function hasProjectRole(
+    env: Env,
+    email: string,
+    projectId: number | string,
+    requiredRole: string
+): Promise<boolean> {
+    const role = await getUserRole(env, email, projectId);
+    if (!role) return false;
+    return hasSufficientRole(role, requiredRole);
+}
+
+/** = Go GetAllProjectsIDsForUser: every project where the user has at least requiredRole. */
+export async function getAllowedProjectIds(
+    env: Env,
+    email: string,
+    requiredRole: string
+): Promise<number[]> {
+    const requiredLevel = ROLE_PRIORITY[requiredRole];
+    if (!requiredLevel) throw new HttpError(400, `Invalid role: ${requiredRole}`);
+
+    const allowedRoles = Object.entries(ROLE_PRIORITY)
+        .filter(([, level]) => level >= requiredLevel)
+        .map(([role]) => role);
+
+    const placeholders = allowedRoles.map(() => "?").join(", ");
+    const { results } = await env.DB.prepare(
+        `SELECT project_id FROM role_management WHERE useremail = ? AND role IN (${placeholders})`
+    )
+        .bind(email, ...allowedRoles)
+        .all<{ project_id: number }>();
+
+    return results.map((r) => r.project_id);
+}
+
+/**
+ * = Go ValidateProjectAccess: 401 if no token, 403 if the caller lacks requiredRole on the
+ * project. Returns the caller's email so handlers can reuse it.
+ */
+export async function requireProjectRole(
+    req: Request,
+    env: Env,
+    projectId: number | string | undefined | null,
+    requiredRole: string
+): Promise<string> {
+    const email = await requireUser(req, env);
+    if (projectId === undefined || projectId === null || projectId === "") {
+        throw new HttpError(400, "Missing project identifier");
+    }
+    const ok = await hasProjectRole(env, email, projectId, requiredRole);
+    if (!ok) throw new HttpError(403, "You don't have sufficient permissions for this project");
+    return email;
+}
+
+/**
+ * Resolve a project_id from a one-row SELECT, used by deletes and order_items where the
+ * project isn't in the request body (mirrors Go's projectIdQuery pattern).
+ */
+export async function resolveProjectId(
+    env: Env,
+    sql: string,
+    ...binds: any[]
+): Promise<number> {
+    const row = await env.DB.prepare(sql)
+        .bind(...binds)
+        .first<{ project_id: number }>();
+    if (!row || row.project_id === undefined || row.project_id === null) {
+        throw new HttpError(400, "Could not determine the project for this resource");
+    }
+    return row.project_id;
+}
+
+/**
+ * = Go CanModifyRole: returns an error message if the action is forbidden, or null if allowed.
+ * Creator may do anything; admin may not grant/revoke creator or downgrade another admin; a
+ * plain user may not modify roles; nobody may modify their own role.
+ */
+export async function canModifyRole(
+    env: Env,
+    actorEmail: string,
+    projectId: number | string,
+    targetEmail: string,
+    oldRole: string,
+    newRole: string
+): Promise<string | null> {
+    if (actorEmail === targetEmail) return "You cannot change your own role";
+
+    const actorRole = await getUserRole(env, actorEmail, projectId);
+    if (!actorRole) return "You don't have permission to modify roles in this project";
+    if (actorRole === "user") return "You don't have permission to modify roles";
+
+    if (actorRole === "admin") {
+        if (oldRole === "admin" && newRole !== "admin" && newRole !== "")
+            return "An admin cannot be downgraded by another admin";
+        if (newRole === "creator") return "An admin cannot grant the creator role";
+        if (oldRole === "admin" && newRole === "")
+            return "An admin cannot be removed by another admin";
+    }
+
+    return null; // creator can do anything
+}


### PR DESCRIPTION
The TS port (api-controller) reproduced the Go controller's queries but dropped its auth/authorization layer and a few features. This restores them:

- adds shared auth/permission helpers (utils/auth.ts) ported from Go's permissions.go + project_id.go + token validation
- requires a valid JWT on every /dwh data endpoint (matches ValidateToken)
- requires admin role on the row's project for all writes (bikes, orders, order_items, customers, warehouse_parts)
- makes bike_models / components / users read-only (parity with Go)
- restores role-management permission logic (canModifyRole) and authenticates the caller; gates the project roster to members
- scopes partcosts, dashboard, and orders-by-email to the caller's projects
- implements orderBy sorting in pagination and fixes a subquery binding-order bug
- implements email verification (GET /auth/verify + Resend send, gated by DISABLE_EMAILS)
- stops leaking raw exception/SQL text in error responses

Verified: tsc --noEmit clean, wrangler deploy --dry-run bundles, and the new SQL validated against a SQLite DB seeded from backend/init_sqlite.